### PR TITLE
Fix incorrect TaskBarDlg alignment in Win11 Bate / 修复在 Win11 中不正确的 TaskBarDlg 对齐问题

### DIFF
--- a/TrafficMonitor/TaskBarDlg.cpp
+++ b/TrafficMonitor/TaskBarDlg.cpp
@@ -440,6 +440,9 @@ bool CTaskBarDlg::AdjustWindowPos()
         return false;
     ::GetWindowRect(m_hMin, m_rcMin); //获得最小化窗口的区域
     ::GetWindowRect(m_hBar, m_rcBar); //获得二级容器的区域
+
+    ::GetWindowRect(m_hNotify, m_rcNotify);
+
     static bool last_taskbar_on_top_or_bottom;
     CheckTaskbarOnTopOrBottom();
     if (m_taskbar_on_top_or_bottom != last_taskbar_on_top_or_bottom)
@@ -463,7 +466,7 @@ bool CTaskBarDlg::AdjustWindowPos()
                 if (theApp.m_is_windows11_taskbar)
                 {
                     if (!theApp.m_taskbar_data.tbar_wnd_snap)
-                        m_rect.MoveToX(m_rcBar.Width() - m_rect.Width() + 2);
+                        m_rect.MoveToX(m_rcNotify.left - m_rect.Width() + 2);
                     else
                         m_rect.MoveToX(m_rcMin.right + 2);
                 }
@@ -975,6 +978,8 @@ BOOL CTaskBarDlg::OnInitDialog()
     m_hTaskbar = ::FindWindow(L"Shell_TrayWnd", NULL);      //寻找类名是Shell_TrayWnd的窗口句柄
     m_hBar = ::FindWindowEx(m_hTaskbar, 0, L"ReBarWindow32", NULL); //寻找二级容器的句柄
     m_hMin = ::FindWindowEx(m_hBar, 0, L"MSTaskSwWClass", NULL);    //寻找最小化窗口的句柄
+    
+    m_hNotify = ::FindWindowEx(m_hTaskbar, 0, L"TrayNotifyWnd", NULL);
 
     //在“Shell_TrayWnd”的子窗口找到类名为“Windows.UI.Composition.DesktopWindowContentBridge”的窗口则认为是Windows11的任务栏
     if (theApp.m_win_version.IsWindows11OrLater())
@@ -986,6 +991,9 @@ BOOL CTaskBarDlg::OnInitDialog()
 
     ::GetWindowRect(m_hMin, m_rcMin);   //获得最小化窗口的区域
     ::GetWindowRect(m_hBar, m_rcBar);   //获得二级容器的区域
+
+    ::GetWindowRect(m_hNotify, m_rcNotify);
+
     m_left_space = m_rcMin.left - m_rcBar.left;
     m_top_space = m_rcMin.top - m_rcBar.top;
 
@@ -995,7 +1003,7 @@ BOOL CTaskBarDlg::OnInitDialog()
     m_rect.bottom = m_window_height;
     m_rect.right = m_rect.left + m_window_width;
 
-    m_connot_insert_to_task_bar = !(::SetParent(this->m_hWnd, m_hBar)); //把程序窗口设置成任务栏的子窗口
+    m_connot_insert_to_task_bar = !(::SetParent(this->m_hWnd, m_hTaskbar)); //把程序窗口设置成任务栏的子窗口
     m_error_code = GetLastError();
     AdjustWindowPos();
 

--- a/TrafficMonitor/TaskBarDlg.h
+++ b/TrafficMonitor/TaskBarDlg.h
@@ -42,6 +42,9 @@ protected:
     HWND m_hTaskbar;	//任务栏窗口句柄
     HWND m_hBar;		//任务栏窗口二级容器的句柄
     HWND m_hMin;		//最小化窗口的句柄
+    HWND m_hNotify;     //任务栏通知区域的句柄
+
+    CRect m_rcNotify;   //任务栏通知区域的矩形区域
     CRect m_rcBar;		//初始状态时任务栏窗口的矩形区域
     CRect m_rcMin;		//最小化窗口的矩形区域
     CRect m_rcMinOri;   //初始状态时最小化窗口的矩形区域


### PR DESCRIPTION
修正在 win11 22581.100 下 TaskBarDlg 的对齐策略。通过以 `TaskBar` 为父对象，并参考 `TrayNotifyWnd` 左侧边缘进行对齐。

**此 PR 未经过通用性验证，仅为修正此问题提供解决思路，请勿直接 merge。**

Issue: #777

**由于未经过详细测试，不保证兼容性和可用性，仅做测试版本的临时解决方案。详细修复方案和稳定版本请静候 Release 和 Windows 11 稳定版本的发布。** **Since it has not been tested in detail, compatibility and availability are not guaranteed, only temporary solutions for the tested version are made. Please wait for Windows 11 stable release for detailed fixes and stable versions.**

Release 文件下载，可供临时使用： Release files are provided for **temporary use only**:

**!!! 2022.07.10 Update !!!**

* [x64_20220710_163826_TrafficMonitor](https://github.com/GZTimeWalker/TrafficMonitor/suites/7291383559/artifacts/294066192)
* [x86_20220710_163818_TrafficMonitor](https://github.com/GZTimeWalker/TrafficMonitor/suites/7291383559/artifacts/294066194)

相关 Github Action 见： [Release CI Action](https://github.com/GZTimeWalker/TrafficMonitor/actions/runs/2644006439)
